### PR TITLE
[SNOW-721864] Add return dict for create_deployment

### DIFF
--- a/src/snowflake/ml/mlflow/deploy/deployment_client.py
+++ b/src/snowflake/ml/mlflow/deploy/deployment_client.py
@@ -83,6 +83,11 @@ class SnowflakeDeploymentClient(BaseDeploymentClient):
                 Defaults to None.
             endpoint (optional): Ignored for now.
 
+        Returns:
+            A dict containing
+                1) `name` of the deployment.
+                2) `udf_name` of the generated Snowflake UDF function.
+
         Raises:
             MlflowException: Raise if specified flavor is not supported.
         """
@@ -92,6 +97,10 @@ class SnowflakeDeploymentClient(BaseDeploymentClient):
         parsed_config = self.parse_config(config)
         normalized_name = self._deploy_helper.normalize_name(name)
         upload_model_from_mlflow(self._session, model_dir_path=model_path, udf_name=normalized_name, **parsed_config)
+        return {
+            "name": name,
+            "udf_name": normalized_name,
+        }
 
     @experimental
     @usage_logging(fields_to_log={"name", "config"})

--- a/tests/test_deployment_client.py
+++ b/tests/test_deployment_client.py
@@ -68,6 +68,17 @@ def test_create_deployment_with_unsupported_flavor(clean_session):
         client.create_deployment("name", "uri", flavor="tensorflow")
 
 
+def test_create_deployment_success(clean_session, monkeypatch):
+    """Expect return dict containing `name` attribute."""
+    util.set_session(clean_session)
+    monkeypatch.setattr("snowflake.ml.mlflow.deploy.deployment_client.upload_model_from_mlflow", MagicMock())
+    monkeypatch.setattr("snowflake.ml.mlflow.deploy.deployment_client._download_artifact_from_uri", MagicMock())
+    client = SnowflakeDeploymentClient("snowflake")
+    res_dict = client.create_deployment("modelx", "uri", flavor="sklearn")
+    assert "name" in res_dict and res_dict["name"] == "modelx"
+    assert "udf_name" in res_dict and res_dict["udf_name"] == "MLFLOW$MODELX"
+
+
 def test_predict_with_missing_arguments(clean_session):
     """Expect raise when missing required arguments."""
     util.set_session(clean_session)


### PR DESCRIPTION
Address one internal customer feedback.
Add return dict for create_deployment
* include `name` as suggested by interface.
* include `udf_name` for ease of use.