### PR TITLE
Skip conda check if not available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         -   id: pyupgrade
             args: [--py38-plus]
 -   repo: https://github.com/PyCQA/isort  # config: .isort.cfg
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 -   repo: https://github.com/psf/black

--- a/src/snowflake/ml/mlflow/util/pkg_util.py
+++ b/src/snowflake/ml/mlflow/util/pkg_util.py
@@ -16,14 +16,9 @@ class DependencyException(RuntimeError):
     pass
 
 
-def validate_conda_installation():
-    """Verify if conda is installed."""
-    if shutil.which("conda") is None:
-        raise DependencyException(
-            "Could not find conda executable. "
-            "Ensure conda is installed as per the instructions "
-            "at https://docs.conda.io/en/latest/miniconda.html"
-        )
+def has_conda_installation() -> bool:
+    """Check if conda is installed. Return false if not."""
+    return not shutil.which("conda") is None
 
 
 def check_compatibility_with_snowflake_conda_channel(requirements_path: str) -> None:
@@ -32,7 +27,9 @@ def check_compatibility_with_snowflake_conda_channel(requirements_path: str) -> 
     Args:
         requirements_path (str): Absolute path to requirements.txt.
     """
-    validate_conda_installation()
+    if not has_conda_installation():
+        return
+
     res = subprocess.run(
         [
             "conda",

--- a/tests/test_pkg_util.py
+++ b/tests/test_pkg_util.py
@@ -10,7 +10,7 @@ from snowflake.ml.mlflow.util.pkg_util import (
     _sanitize,
     check_compatibility_with_snowflake_conda_channel,
     extract_package_requirements,
-    validate_conda_installation,
+    has_conda_installation,
 )
 
 TEST_REQUIREMENTS = [
@@ -151,20 +151,19 @@ def test_extract_package_requirements(mock_snow_channel):
     assert res2 == expected2
 
 
-def test_validate_conda_installation_when_not_present(monkeypatch):
+def test_has_conda_installation_when_not_present(monkeypatch):
     """Expect raise when conda is not installed."""
     mock = MagicMock()
     monkeypatch.setattr("shutil.which", mock)
     mock.return_value = None
-    with pytest.raises(RuntimeError, match=r"Could not find conda executable.*"):
-        validate_conda_installation()
+    assert has_conda_installation() is False
 
 
-def test_validate_conda_installation_when_present(monkeypatch):
+def test_has_conda_installation_when_present(monkeypatch):
     mock = MagicMock()
     monkeypatch.setattr("shutil.which", mock)
     mock.return_value = "/opt/bin/miniconda"
-    validate_conda_installation()
+    assert has_conda_installation() is True
 
 
 def test_check_compatibility_with_invalid_response(monkeypatch):


### PR DESCRIPTION
To avoid any friction. If conda is not available, skip the conda full package compatibility check and fallback to default Snowpark package version validations against `information_schema.packages`.